### PR TITLE
Add support for untrusted workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,11 @@
 		"onLanguage:yaml"
 	],
 	"main": "./out/extension.js",
+	"capabilities": {
+		"untrustedWorkspaces": {
+			"supported": true
+		}
+	},
 	"contributes": {},
 	"scripts": {
 		"vscode:prepublish": "npm run compile",


### PR DESCRIPTION
I believe untrusted workspaces should be fine because all the tree-sitter stuff is run in wasm sandbox