### PR TITLE
Add C# support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # For generating .wasm files for parsers
 # See https://www.npmjs.com/package/web-tree-sitter
-languages = cpp c_sharp bash go javascript json markdown python ruby rust tsx typescript yaml
+languages = cpp c-sharp bash go javascript json markdown python ruby rust tsx typescript yaml
 
 .PHONY: parsers
 parsers: $(addprefix parsers/tree-sitter-,$(addsuffix .wasm,$(languages)))
@@ -17,6 +17,6 @@ parsers/tree-sitter-tsx.wasm: node_modules/tree-sitter-typescript/tsx/package.js
 	npx tree-sitter build-wasm $(dir $^)
 	mv $(notdir $@) $@
 
-parsers/tree-sitter-c_sharp.wasm: node_modules/tree-sitter-c-sharp/package.json
+parsers/tree-sitter-c-sharp.wasm: node_modules/tree-sitter-c-sharp/package.json
 	npx tree-sitter build-wasm $(dir $^)
-	mv $(notdir $@) $@
+	mv tree-sitter-c_sharp.wasm $@

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # For generating .wasm files for parsers
 # See https://www.npmjs.com/package/web-tree-sitter
-languages = cpp bash go javascript json markdown python ruby rust tsx typescript yaml
+languages = cpp c_sharp bash go javascript json markdown python ruby rust tsx typescript yaml
 
 .PHONY: parsers
 parsers: $(addprefix parsers/tree-sitter-,$(addsuffix .wasm,$(languages)))
@@ -14,5 +14,9 @@ parsers/tree-sitter-typescript.wasm: node_modules/tree-sitter-typescript/typescr
 	mv $(notdir $@) $@
 
 parsers/tree-sitter-tsx.wasm: node_modules/tree-sitter-typescript/tsx/package.json
+	npx tree-sitter build-wasm $(dir $^)
+	mv $(notdir $@) $@
+
+parsers/tree-sitter-c_sharp.wasm: node_modules/tree-sitter-c-sharp/package.json
 	npx tree-sitter build-wasm $(dir $^)
 	mv $(notdir $@) $@

--- a/package.json
+++ b/package.json
@@ -81,5 +81,10 @@
 		"jsonc-parser": "^2.1.0",
 		"tar": ">=4.4.2",
 		"web-tree-sitter": "^0.19.3"
+	},
+	"__metadata": {
+		"id": "d2779d85-368b-4205-9b9c-cc585a446410",
+		"publisherDisplayName": "Pokey Rule",
+		"publisherId": "23338867-1255-47fc-a9fc-1af10882a056"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -81,10 +81,5 @@
 		"jsonc-parser": "^2.1.0",
 		"tar": ">=4.4.2",
 		"web-tree-sitter": "^0.19.3"
-	},
-	"__metadata": {
-		"id": "d2779d85-368b-4205-9b9c-cc585a446410",
-		"publisherDisplayName": "Pokey Rule",
-		"publisherId": "23338867-1255-47fc-a9fc-1af10882a056"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 	],
 	"activationEvents": [
 		"onLanguage:cpp",
+		"onLanguage:csharp",
 		"onLanguage:bash",
 		"onLanguage:go",
 		"onLanguage:javascript",
@@ -59,6 +60,7 @@
 		"@types/node": "^8.10.25",
 		"electron-rebuild": "^2.3.5",
 		"tree-sitter-bash": "^0.19.0",
+		"tree-sitter-c-sharp": "^0.19.0",
 		"tree-sitter-cli": "^0.19.4",
 		"tree-sitter-cpp": "^0.19.0",
 		"tree-sitter-go": "^0.19.0",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,7 +11,7 @@ const languages: {
 } = {
   bash: { module: "tree-sitter-bash" },
   cpp: { module: "tree-sitter-cpp" },
-  csharp: { module: "tree-sitter-c_sharp" },
+  csharp: { module: "tree-sitter-c-sharp" },
   go: { module: "tree-sitter-go" },
   javascript: { module: "tree-sitter-javascript" },
   javascriptreact: { module: "tree-sitter-javascript" },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,7 @@ const languages: {
 } = {
   bash: { module: "tree-sitter-bash" },
   cpp: { module: "tree-sitter-cpp" },
+  csharp: { module: "tree-sitter-c_sharp" },
   go: { module: "tree-sitter-go" },
   javascript: { module: "tree-sitter-javascript" },
   javascriptreact: { module: "tree-sitter-javascript" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2036,8 +2036,10 @@ tree-sitter-json@^0.19.0:
   dependencies:
     nan "^2.14.1"
 
-"tree-sitter-markdown@file:../tree-sitter-markdown":
+tree-sitter-markdown@^0.7.1:
   version "0.7.1"
+  resolved "https://registry.yarnpkg.com/tree-sitter-markdown/-/tree-sitter-markdown-0.7.1.tgz#9411df0b832a4798808eb1ce3434f1cfee3e2196"
+  integrity sha512-hB3sEm1JtfoRUzGvknL9RQrS/LJvbrdI9WfGbU8gE6xMjbbAKHfHrNzh4Oo9JxksfUf6UEMxy91acRajEIOnGQ==
   dependencies:
     nan "^2.14.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1996,6 +1996,13 @@ tree-sitter-bash@^0.19.0:
     nan "^2.14.0"
     prebuild-install "^5.3.3"
 
+tree-sitter-c-sharp@^0.19.0:
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/tree-sitter-c-sharp/-/tree-sitter-c-sharp-0.19.0.tgz#89a940fc0f2c05e7d0248c8de101fba01fb73e5a"
+  integrity sha512-Y2T7lisxbJHYg44hxE8XQPFpJLUE5jZSfKO4jyOuNLFS0wpN1wux6SucU4aWTkTfyaiyGWZ10GvEIQ++ZDAVTQ==
+  dependencies:
+    nan "^2.14.0"
+
 tree-sitter-cli@^0.19.4:
   version "0.19.4"
   resolved "https://registry.yarnpkg.com/tree-sitter-cli/-/tree-sitter-cli-0.19.4.tgz#99b03f9de1bb225dbe898fe83b5a30478c838123"
@@ -2029,10 +2036,8 @@ tree-sitter-json@^0.19.0:
   dependencies:
     nan "^2.14.1"
 
-tree-sitter-markdown@^0.7.1:
+"tree-sitter-markdown@file:../tree-sitter-markdown":
   version "0.7.1"
-  resolved "https://registry.yarnpkg.com/tree-sitter-markdown/-/tree-sitter-markdown-0.7.1.tgz#9411df0b832a4798808eb1ce3434f1cfee3e2196"
-  integrity sha512-hB3sEm1JtfoRUzGvknL9RQrS/LJvbrdI9WfGbU8gE6xMjbbAKHfHrNzh4Oo9JxksfUf6UEMxy91acRajEIOnGQ==
   dependencies:
     nan "^2.14.0"
 


### PR DESCRIPTION
Pretty straightforward; the Makefile tweak is because the package is named `tree-sitter-c-sharp` but the module produced is named `tree-sitter-c_sharp.wasm`