### PR TITLE
Build web-tree-sitter

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
 	"contributes": {},
 	"scripts": {
 		"vscode:prepublish": "npm run compile",
-		"compile": "tsc -p ./ && make parsers",
+		"compile": "make compile",
 		"watch": "tsc -watch -p ./",
 		"postinstall": "node ./node_modules/vscode/bin/install",
 		"test": "npm run compile && node ./out/test",
@@ -76,6 +76,7 @@
 		"tree-sitter-clojure": "github:sogaiu/tree-sitter-clojure#master",
 		"tree-sitter-cpp": "^0.19.0",
 		"tree-sitter-go": "^0.19.0",
+		"tree-sitter-haskell": "github:tree-sitter/tree-sitter-haskell#d6ccd2d9c40bdec29fee0027ef04fe5ff1ae4ceb",
 		"tree-sitter-html": "^0.19.0",
 		"tree-sitter-java": "^0.19.1",
 		"tree-sitter-javascript": "^0.19.0",
@@ -96,7 +97,6 @@
 	},
 	"dependencies": {
 		"jsonc-parser": "^2.1.0",
-		"tar": ">=4.4.2",
-		"web-tree-sitter": "^0.19.4"
+		"tar": ">=4.4.2"
 	}
 }


### PR DESCRIPTION
This pull request changes the build process of vscode-parse-tree to build web-tree-sitter, rather than depending on the published version in the NPM package registry, as it frequently lags behind the main version.